### PR TITLE
Update staging.rb turn off assets.debug

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -37,7 +37,7 @@ DIL::Application.configure do
   config.assets.compress = false
 
   # Expands the lines which load the assets
-  config.assets.debug = true
+  #config.assets.debug = true
   
   # For emailing exceptions that occur in the app
   config.middleware.use ExceptionNotifier,


### PR DESCRIPTION
Turning off config.assets.debug in staging.rb seems to remove the js confusion on the assets.
