### PR TITLE
create migrations to drop tables related to removed features

### DIFF
--- a/db/migrate/20150212175935_remove_uploads_table.rb
+++ b/db/migrate/20150212175935_remove_uploads_table.rb
@@ -1,0 +1,5 @@
+class RemoveUploadsTable < ActiveRecord::Migration
+  def change
+    drop_table :upload_files
+  end
+end

--- a/db/migrate/20150212180547_remove_image_processing_requests.rb
+++ b/db/migrate/20150212180547_remove_image_processing_requests.rb
@@ -1,0 +1,5 @@
+class RemoveImageProcessingRequests < ActiveRecord::Migration
+  def change
+    drop_table :image_processing_requests
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140811191429) do
+ActiveRecord::Schema.define(version: 20150212180547) do
 
   create_table "bookmarks", force: true do |t|
     t.integer  "user_id",     null: false
@@ -32,8 +32,8 @@ ActiveRecord::Schema.define(version: 20140811191429) do
     t.datetime "failed_at"
     t.string   "locked_by"
     t.string   "queue"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
   end
 
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority"
@@ -43,16 +43,6 @@ ActiveRecord::Schema.define(version: 20140811191429) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string   "code",       null: false
-  end
-
-  create_table "image_processing_requests", force: true do |t|
-    t.string   "image_pid",      limit: 50
-    t.string   "image_filename", limit: 50
-    t.string   "email",                     default: "",         null: false
-    t.string   "status",         limit: 25,                      null: false
-    t.datetime "created_at",                                     null: false
-    t.datetime "updated_at",                                     null: false
-    t.string   "pid",                       default: "migrated", null: false
   end
 
   create_table "locked_objects", force: true do |t|
@@ -77,29 +67,20 @@ ActiveRecord::Schema.define(version: 20140811191429) do
     t.integer "user_id", null: false
   end
 
-  create_table "upload_files", force: true do |t|
-    t.string   "pid"
-    t.integer  "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  add_index "upload_files", ["user_id"], name: "index_upload_files_on_user_id"
-
   create_table "users", force: true do |t|
-    t.string   "email",                              default: "", null: false
-    t.string   "encrypted_password",     limit: 128, default: "", null: false
+    t.string   "email",                  default: "", null: false
+    t.string   "encrypted_password",     default: "", null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                      default: 0
+    t.integer  "sign_in_count",          default: 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
-    t.datetime "created_at",                                      null: false
-    t.datetime "updated_at",                                      null: false
-    t.string   "uid",                                             null: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
+    t.string   "uid",                                 null: false
     t.text     "affiliations"
   end
 


### PR DESCRIPTION
these tables are related to the upload images feature, which we're not using anymore

Remember that you'll need to run a rake db:migrate !!!!!