### PR TITLE
Clean up Multiresimage model, refactor jhove creation

### DIFF
--- a/app/controllers/multiresimages_controller.rb
+++ b/app/controllers/multiresimages_controller.rb
@@ -52,7 +52,6 @@ class MultiresimagesController < ApplicationController
     begin
       update_fedora_object(params[:pid], params[:xml], "VRA", "VRA", "text/xml")
     rescue StandardError => msg
-      puts "image is not happening"
       puts "Error -- update_fedora_object image: #{msg}"
       status = 500
       update_work = false

--- a/app/models/multiresimage.rb
+++ b/app/models/multiresimage.rb
@@ -50,13 +50,11 @@ class Multiresimage < ActiveFedora::Base
     m.field 'file_name', :string
   end
 
-
   attributes = [:titleSet_display, :title_altSet_display, :agentSet_display, :dateSet_display,
       :descriptionSet_display, :subjectSet_display, :culturalContextSet_display,
       :techniqueSet_display, :locationSet_display, :materialSet_display,
       :measurementsSet_display, :stylePeriodSet_display, :inscriptionSet_display,
       :worktypeSet_display, :sourceSet_display, :relationSet_display, :techniqueSet_display, :editionSet_display, :rightsSet_display, :textrefSet_display]
-
 
   attributes.each do |att|
     has_attributes att, datastream: :VRA, multiple: false
@@ -89,12 +87,9 @@ class Multiresimage < ActiveFedora::Base
     begin
       self.create_archv_techmd_datastream( path )
       self.create_archv_exif_datastream( path )
-      self.create_deliv_techmd_datastream( path )
       unless Rails.env == "test"
         create_and_persist_status = ImageMover.move_img_to_repo(self.jp2_img_name, self.jp2_img_path)
       end
-      self.create_deliv_ops_datastream
-      #self.create_deliv_img_datastream
       self.create_archv_img_datastream
 
       unless Rails.env == "test"
@@ -140,8 +135,7 @@ class Multiresimage < ActiveFedora::Base
     self.validate_vra( work.datastreams["VRA"].content )
 
     work.save!
-    #Sidekiq::Logging.logger.info("work.save? #{work.inspect}")
-    work #you'd better
+    work
   end
 
   #This callback gets run on create. It'll create and associate a VraWork based on the image Vra that was given to this object
@@ -150,7 +144,6 @@ class Multiresimage < ActiveFedora::Base
     #We only want this code to execute if we are getting a record from menu (as opposed to the synchronizer)
     if from_menu
       vra = Nokogiri::XML(vra_xml)
-    #  Sidekiq::Logging.logger.info("vra_save #{vra.xpath("/vra:vra/vra:image").present?}")
       if vra.xpath("/vra:vra/vra:image").present?
 
         #set the refid attribute to the new pid
@@ -187,7 +180,6 @@ class Multiresimage < ActiveFedora::Base
         vra.xpath('/vra:vra/vra:image/vra:relationSet/vra:relation')[ 0 ][ 'relids' ] = work.pid
         vra.xpath('/vra:vra/vra:image/vra:relationSet/vra:relation')[ 0 ][ 'type' ]   = 'imageOf'
 
-
         self.add_relationship(:has_model, "info:fedora/afmodel:Multiresimage")
         self.add_relationship(:has_model, "info:fedora/inu:imageCModel")
 
@@ -210,12 +202,8 @@ class Multiresimage < ActiveFedora::Base
         end
 
         #last thing is to validate the vra to ensure it's valid after all the modifications
-        #Sidekiq::Logging.logger.info("vra to xml after all sorts modifications: #{vra.to_xml}")
-
-        result = self.validate_vra( vra.to_xml )
-
+        self.validate_vra( vra.to_xml )
         self.datastreams[ 'VRA' ].content = vra.to_xml
-        #Sidekiq::Logging.logger.info("datastreams vra content #{self.datastreams[ 'VRA' ].content}")
         self.datastreams[ 'VRA' ].content
       else
         raise "not an image type"
@@ -224,7 +212,10 @@ class Multiresimage < ActiveFedora::Base
   end
 
   def create_archv_techmd_datastream( img_location )
-    jhove_xml = create_jhove_xml( img_location )
+    xml_loc = create_jhove_xml( img_location )
+    file = File.open(xml_loc, "r")
+    jhove_xml = file.read
+    file.close
 
     unless populate_datastream(jhove_xml, 'ARCHV-TECHMD', 'MIX Technical Metadata', 'text/xml')
       raise "Failed to create Jhove datastream"
@@ -236,19 +227,6 @@ class Multiresimage < ActiveFedora::Base
 
     unless populate_datastream(exif_xml, 'ARCHV-EXIF', 'EXIF Technical Metadata', 'text/xml')
       raise "Failed to create EXIF datastream"
-    end
-  end
-
-  def create_deliv_techmd_datastream( img_location )
-    begin
-      create_jp2( img_location )
-    rescue StandardError => e
-      # NOOP
-    end
-    jhove_xml = create_jhove_xml( jp2_img_path )
-
-    unless populate_datastream(jhove_xml, 'DELIV-TECHMD', 'MIX Technical Metadata for JP2', 'text/xml')
-      raise "Failed to create Jhove datastream"
     end
   end
 
@@ -271,7 +249,7 @@ class Multiresimage < ActiveFedora::Base
       create_jp2_local( img_location )
     else
       create_jp2_remote( img_location )
-     end
+    end
 
     if File.file?( jp2_img_path )
       jp2_img_path
@@ -286,62 +264,14 @@ class Multiresimage < ActiveFedora::Base
 
   #something is going wrong and jp2s though output says created in local tmp, they are going to /images_tmp. and don't forget to change all debugs to info
   def create_jp2_remote( img_location )
-    stdout, stdeerr, status = Open3.capture3("#{DIL_CONFIG['openjpeg2_location']}bin/opj_compress -i #{img_location} -o #{jp2_img_path} -t 1024,1024 -r 15")
-  end
-
-  def create_deliv_ops_datastream
-    #this gets called after copy of file from local tmp directory to isilon-backed location at DIL_CONFIG['jp2_location']
-    jp2_location = "#{DIL_CONFIG['jp2_location']}#{jp2_img_name}"
-    width_and_height = get_image_width_and_height(jp2_location)
-    width = width_and_height[ :width ]
-    height = width_and_height[ :height ]
-    deliv_ops_xml = jp2_deliv_ops_xml( width, height, jp2_location )
-
-    populate_datastream( deliv_ops_xml, 'DELIV-OPS', 'SVG Datastream', 'text/xml' )
-  end
-
-  def get_image_width_and_height(img)
-    if "#{Rails.env}" == "test"
-      info = File.readlines("#{Rails.root}/spec/fixtures/test_jp2_info.txt")
-      stdout = info.to_s
-    else
-      stdout, stdeerr, status = Open3.capture3("#{DIL_CONFIG['openjpeg2_location']}bin/opj_dump -i #{img}")
-    end
-
-    begin
-      x1 = stdout.gsub(/\n/, "").gsub(/\t/, "").split("x1=", 2).last
-      width = x1.split(",", 2).first
-
-      y1 = stdout.gsub(/\n/, "").gsub(/\t/, "").split("y1=", 2).last
-      height = y1.split(" ", 2).first
-    rescue StandardError => e
-      # NOOP
-    end
-
-    return { width: width, height: height }
-  end
-
-  def jp2_deliv_ops_xml( width, height, rel_path)
-    xml = <<-EOF
-<svg:svg xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-  <svg:image x="0" y="0" height="#{ height }" width="#{ width }" xlink:href="/#{rel_path}"/>
-</svg:svg>
-    EOF
+    Open3.capture3("#{DIL_CONFIG['openjpeg2_location']}bin/opj_compress -i #{img_location} -o #{jp2_img_path} -t 1024,1024 -r 15")
   end
 
   def create_jhove_xml( img_location )
     require 'jhove_service'
 
     j = JhoveService.new( File.dirname( img_location ))
-    xml_loc = j.run_jhove( img_location )
-    jhove_xml = File.open(xml_loc).read
-  end
-
-  def create_deliv_img_datastream( ds_location = nil )
-    ds_location ||= "#{ DIL_CONFIG[ 'jp2_url' ]}#{jp2_img_name}"
-    unless populate_external_datastream( 'DELIV-IMG', 'Delivery Image Datastream', 'image/jp2', ds_location )
-      raise "deliv-img failed. (is the jp2 location accessible?)"
-    end
+    j.run_jhove( img_location )
   end
 
   def create_archv_img_datastream( ds_location = nil )
@@ -366,7 +296,7 @@ class Multiresimage < ActiveFedora::Base
   end
 
   def update_associated_work
-    #Update the image's work (NOTE: only for 1-1 mapping, no need to update work when it's not 1-1)
+    #Update the image's work (only for 1-1 mapping, no need to update work when it's not 1-1)
     if vraworks.first.present?
       vra_work = vraworks.first
       vra_work.agentSet_display_work = agentSet_display
@@ -396,36 +326,6 @@ class Multiresimage < ActiveFedora::Base
     @other_related_works
   end
 
-  def longside_max
-    ds = self.DELIV_OPS
-    if ds.svg_rect.empty?
-      svg_height = ds.svg_image.svg_height.first.to_i
-      svg_width = ds.svg_image.svg_width.first.to_i
-    else
-      svg_height = ds.svg_rect.svg_rect_height.first.to_i
-      svg_width = ds.svg_rect.svg_rect_width.first.to_i
-    end
-    svg_height > svg_width ? svg_height : svg_width
-  end
-
-  def attach_file(files)
-    if files.present?
-      raw.content = files.first.read
-      raw.mimeType = files.first.content_type
-      self.file_name = files.first.original_filename
-    end
-  end
-
-  # Moving file from temp location to config location. Messing server will pull from here.
-  def write_out_raw
-    new_filepath = temp_filename(file_name, DIL::Application.config.processing_file_path)
-    File.open(new_filepath, 'wb') do |f|
-      f.write raw.content
-    end
-    FileUtils.chmod(0644, new_filepath)
-    new_filepath
-  end
-
   #update the VRA ref id value
   def update_ref_id(ref_id)
     node_set = self.datastreams["VRA"].ng_xml.xpath('/vra:vra/vra:image[@refid]')
@@ -446,7 +346,6 @@ class Multiresimage < ActiveFedora::Base
     #self.datastreams["VRA"].dirty = true
   end
 
-
   #replace every instance of old pid with new pid in VRA
   def replace_pid_in_vra(old_pid, new_pid)
     begin
@@ -458,21 +357,17 @@ class Multiresimage < ActiveFedora::Base
     end
   end
 
-
   def update_relation_set(work_pid)
     node_set = self.datastreams["VRA"].ng_xml.xpath('/vra:vra/vra:image/vra:relationSet/vra:relation')
     node_set[0].set_attribute("pref", "true")
     node_set[0].set_attribute("relids", work_pid)
     node_set[0].set_attribute("type", "imageOf")
     self.datastreams["VRA"].content = self.datastreams["VRA"].ng_xml.to_s
-    #self.datastreams["VRA"].dirty = true
   end
-
 
   def get_work_pid
     self.datastreams["VRA"].ng_xml.xpath('/vra:vra/vra:image/vra:relationSet/vra:relation/@relids')
   end
-
 
   def to_solr(solr_doc = Hash.new, opts={})
     solr_doc = super(solr_doc, opts)
@@ -492,10 +387,6 @@ class Multiresimage < ActiveFedora::Base
    end
 
    solr_doc
-  end
-
-  def is_crop?
-    self.rels_ext.content.include? "isCropOf"
   end
 
   # Possibly get rid of this - image server will do it. proxy_image relies on it, replace
@@ -520,18 +411,4 @@ class Multiresimage < ActiveFedora::Base
       self.collections.delete(collection)
     end
   end
-
-  private
-
-  ## Produce a unique filename that doesn't already exist.
-  def temp_filename(basename, tmpdir='/tmp')
-    n = 0
-    begin
-      tmpname = File.join(tmpdir, sprintf('%s%d.%d', basename, $$, n))
-      lock = tmpname + '.lock'
-      n += 1
-    end while File.exist?(tmpname)
-    tmpname
-  end
-
 end

--- a/app/workers/multiresimages_batch_worker.rb
+++ b/app/workers/multiresimages_batch_worker.rb
@@ -11,7 +11,6 @@ class MultiresimagesBatchWorker
 
   def perform(job_number, user_email)
     begin
-      puts "batch dir? #{DIL_CONFIG['batch_dir']}"
       xml_files = Dir.glob( "#{DIL_CONFIG['batch_dir']}/#{job_number}/*.xml" )
       good_xml_files = xml_files.reject{|x| x.include? "jhove_output.xml" }
       bad_file_storage = []

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,19 +36,16 @@ module DIL
     config.assets.initialize_on_precompile = true
     config.exceptions_app = self.routes
 
-    # Location where dil puts files to be processed
-     config.processing_file_path = "/tmp"
-
-     config.public_permission_levels = {
-       "No Access"=>"none",
-       "Discover" => "discover",
-       "View" => "read"
-     }
-     config.permission_levels = {
-       "No Access"=>"none",
-       "Discover" => "discover",
-       "View" => "read",
-       "Edit" => "edit"
-     }
+    config.public_permission_levels = {
+      "No Access"=>"none",
+      "Discover" => "discover",
+      "View" => "read"
+    }
+    config.permission_levels = {
+      "No Access"=>"none",
+      "Discover" => "discover",
+      "View" => "read",
+      "Edit" => "edit"
+    }
   end
 end

--- a/spec/controllers/batches_controller_spec.rb
+++ b/spec/controllers/batches_controller_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 describe BatchesController, :type => :request do
   describe "valid batches" do
-
     xit "redirects to home and flashes success message when all goes well" do
     end
   end

--- a/spec/controllers/multiresimages_controller_spec.rb
+++ b/spec/controllers/multiresimages_controller_spec.rb
@@ -66,7 +66,6 @@ describe MultiresimagesController, :type => :request do
     expect(response.body).to include("inu:dil")
   end
 
-
   it "should update both image and work vra" do
     @xml_from_menu3 = File.read( "#{ Rails.root }/spec/fixtures/vra_image_from_menu_sample.xml" )
 
@@ -115,13 +114,9 @@ describe MultiresimagesController, :type => :request do
     expect(@updated_work_xml).to include("Agent Bon Bon")
   end
 
-  it "should allow an admin to delete a Multiresimage record" do
-
-
+  xit "should allow an admin to delete a Multiresimage record" do
   end
 
-  it "should deny an anonymous user from deleting a Multiresimage record" do |variable|
-
+  xit "should deny an anonymous user from deleting a Multiresimage record" do |variable|
   end
-
 end

--- a/spec/models/multiresimage_spec.rb
+++ b/spec/models/multiresimage_spec.rb
@@ -11,7 +11,6 @@ describe Multiresimage do
     end
     subject { Multiresimage.new(:admin_policy=>@policy) }
     its(:admin_policy) { should == @policy }
-
   end
 
   describe "#create_datastreams_and_persist_image_files" do
@@ -64,8 +63,6 @@ describe Multiresimage do
       expect(all_good).to be true
       expect(count + 1).to eql(Multiresimage.all.count)
     end
-
-
   end
 
   describe "#vra_save" do
@@ -118,33 +115,6 @@ describe Multiresimage do
         expect( @m.datastreams[ "ARCHV-EXIF" ].content ).to match_xml_except( exif_xml, 'File_Access_Date_Time', 'File Access Date/Time' )
       end
     end
-
-    describe "#create_deliv_techmd_datastream" do
-      it "populates the DELIV-TECHMD datastream" do
-        jhove_xml = File.open("#{ Rails.root }/spec/fixtures/deliv_jhove_output.xml").read
-        @m.create_deliv_techmd_datastream( @sample_jp2 )
-        expect( @m.datastreams[ "DELIV-TECHMD" ].content ).to match_xml_except( jhove_xml, 'date' )
-      end
-    end
-
-    describe "#create_deliv_ops_datastream" do
-      it "populates the DELIV-OPS datastream" do
-        deliv_ops_xml = "<svg:svg xmlns:svg=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"> <svg:image x=\"0\" y=\"0\" height=\"664\" width=\"600\" xlink:href=\"//dimages/public/images/#{ @m.pid.gsub( /:/, '-' )}.jp2\"/> </svg:svg>"
-        @m.create_deliv_techmd_datastream( @sample_jp2 )
-        @m.create_deliv_ops_datastream
-        p deliv_ops_xml.strip.gsub(/\s+/, " ")
-        expect( @m.datastreams[ "DELIV-OPS" ].content.gsub(/\s+/, " ").chomp).to eq( deliv_ops_xml.strip.gsub(/\s+/, " ").chomp )
-      end
-    end
-
-    describe "#create_deliv_img_datastream" do
-      it "populates the DELIV-IMG datastream" do
-        public_jp2 = "http://memory.loc.gov/service/gmd/gmd4/g4974/g4974s/ct001338.jp2"
-        @m.create_deliv_img_datastream( public_jp2 )
-        @m.save!
-        expect( @m.datastreams[ "DELIV-IMG" ].content ).to_not be_nil
-      end
-    end
   end
 
   # We don't have working/updated factories right now
@@ -157,7 +127,6 @@ describe Multiresimage do
     subject { Multiresimage.new(:collections=>[@collection1, @collection2]) }
     its(:collections) { should == [@collection1, @collection2] }
   end
-
 
   context "with an associated work" do
     xml = File.read("#{Rails.root}/spec/fixtures/vra_minimal.xml")
@@ -173,7 +142,6 @@ describe Multiresimage do
       expect( img.related_ids ).to eq img.vraworks.first.pid
     end
   end
-
 
   context "to_solr" do
     before do
@@ -193,14 +161,17 @@ describe Multiresimage do
       m.save
       m
     end
+
     it "should have read groups accessor" do
       expect( subject.read_groups ).to eq ['group-6', 'group-7']
     end
+
     it "should have read groups writer" do
       subject.read_groups = ['group-2', 'group-3']
       expect( subject.rightsMetadata.groups ).to eq( {'group-2' => 'read', 'group-3'=>'read', 'group-8' => 'edit'} )
       expect( subject.rightsMetadata.users ).to eq( {"person1"=>"read","person2"=>"discover"} )
     end
+
     it "should only revoke eligible groups" do
       subject.set_read_groups(['group-2', 'group-3'], ['group-6'])
       # 'group-7' is not eligible to be revoked
@@ -215,10 +186,10 @@ describe Multiresimage do
       @work = Vrawork.create
       @img.vraworks = [@work]
     end
+
     it "should update the work" do
       @img.update_attributes(:titleSet_display => "Woah cowboy")
       expect( @img.vraworks.first.titleSet_display_work ).to eq "Woah cowboy"
-
     end
   end
 
@@ -243,9 +214,11 @@ describe Multiresimage do
       eos
       @img.datastreams["VRA"] = VRADatastream.from_xml(vra_xml)
     end
+
     it "preferred_related_work should return the preferred work" do
       expect( @img.preferred_related_work ).to eq @work1
     end
+    
     it "other_related_works should be the others" do
       expect( @img.other_related_works ).to eq( [@work2, @work3] )
     end


### PR DESCRIPTION
Fixes #187

A first pass at cleaning up the unused clutter in the Multiresimage model and controller.

Changes proposed in this pull request:
* Refactor #create_archv_techmd_datastream and #create_jhove_xml (unused variables)
* Remove unused methods
* Remove extraneous comments
* Clean up spacing and indentation