### PR TITLE
working vra endpoint with a bit of authorization

### DIFF
--- a/app/controllers/technical_metadata_controller.rb
+++ b/app/controllers/technical_metadata_controller.rb
@@ -2,7 +2,7 @@ class TechnicalMetadataController < ApplicationController
 
   def show
     @obj = ActiveFedora::Base.find(params[:id], :cast=>true)
-    authorize! :view_technical_metadata, @obj
+    authorize! :view_technical_metadata, @obj unless params[:type] == "VRA"
     body = @obj.datastreams[params[:type]].content
     render :text=> body, :content_type => Mime::XML
   end


### PR DESCRIPTION
Fixes #203 

Opens VRA endpoint to the world

go to http://localhost:3331/technical_metadata/inu:dil-af3c7e97-8fee-4a3d-8584-913fd3089c92/VRA (locally) and see VRA regardless of authentication status

