### PR TITLE
Use new helper for riiif images

### DIFF
--- a/app/views/institutional_collections/images.html.erb
+++ b/app/views/institutional_collections/images.html.erb
@@ -12,7 +12,7 @@
         <tr>
           <tr>
           <td><a href="/multiresimages/<%=document[:id]%>">
-          <%= image_tag("/image-service" + Riiif::Engine.routes.url_helpers.image_path("#{document[:id]}".gsub!(/:/, '-'), size: ',50')) %></td>
+          <%= image_tag(Riiif::Engine.routes.url_helpers.image_path("#{document[:id]}".gsub!(/:/, '-'), size: ',50')) %></td>
           <td><%=document[:id] %><br /><%=document[:title_display_tesim].first%></td>
           <td><small><%=document[:location_display_tesim].first%></small></td>
           <td>


### PR DESCRIPTION
Fixes #171 

Thumbnails work with the latest helper for the riiif image_service.