### PR TITLE
Add a thumbnail_url property on InstitutionalCollections

### DIFF
--- a/app/controllers/institutional_collections_controller.rb
+++ b/app/controllers/institutional_collections_controller.rb
@@ -102,9 +102,9 @@ class InstitutionalCollectionsController < CatalogController
 
     if ( params[:institutional_collection][:rights_description] or params[:institutional_collection][:description] )
       attr_hash = { :rights_description=> params[:institutional_collection][:rights_description],
-                    :description=>params[:institutional_collection][:description]}
+                    :description=>params[:institutional_collection][:description], :thumbnail_url=> params[:institutional_collection][:thumbnail_url] }
       if @institutional_collection.update_attributes(attr_hash)
-        flash[:success]="Collection info successfully updated"
+        flash[:notice]="Collection info successfully updated"
         redirect_to institutional_collections_path
       else
         render :action => :edit

--- a/app/models/institutional_collection.rb
+++ b/app/models/institutional_collection.rb
@@ -11,7 +11,6 @@ class InstitutionalCollection < ActiveFedora::Base
   include Hydra::ModelMethods
 
   has_many :multiresimages, :class_name=> "Multiresimage", :property=> :has_collection_member
-  has_many :multiresimages, :class_name=> "Multiresimage", :property=> :has_representative_member
 
   has_metadata 'descMetadata', type: ActiveFedora::QualifiedDublinCoreDatastream do |m|
     m.title :type=> :text, :index_as=>[:searchable]
@@ -25,16 +24,16 @@ class InstitutionalCollection < ActiveFedora::Base
         # ex: Unit|Title
         # redundant to store them but not sure we want to mess with the existing title setup...
         m.field "title_part", :string
-        m.field "unit_part"
+        m.field "unit_part", :string
         m.field "rights_description", :string
+        m.field "thumbnail_url", :string
   end
 
-  has_attributes :title_part, :unit_part, :rights_description, datastream: 'properties', multiple: false
+  has_attributes :title_part, :unit_part, :rights_description, :thumbnail_url, datastream: 'properties', multiple: false
   has_attributes :title, :description, datastream: 'descMetadata', multiple: false
   has_attributes :license_title, datastream: 'rightsMetadata', at: [:license, :title], multiple: false
   has_attributes :license_description, datastream: 'rightsMetadata', at: [:license, :description], multiple: false
   has_attributes :license_url, datastream: 'rightsMetadata', at: [:license, :url], multiple: false
-
 
   def make_public
     #this refers to the rights in the defaultRights datastream, (the rights that are inhertied by images)
@@ -55,20 +54,6 @@ class InstitutionalCollection < ActiveFedora::Base
   end
 
   def collection_unit_formatter
-   title.split("|")[0]
+    title.split("|")[0]
   end
-
-  def set_representative_image(image)
-    unless self.relationships(:has_representative_member).empty?
-      self.remove_relationship(:has_representative_member, self.relationships(:has_representative_member).first)
-    end
-    self.add_relationship(:has_representative_member, image)
-  end
-
-  def representative_image_pid
-    unless self.relationships(:has_representative_member).empty?
-      return self.relationships(:has_representative_member).first.gsub(/info:fedora\//, '')
-    end
-  end
-
 end

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -1,10 +1,11 @@
   <% InstitutionalCollection.all.each_with_index do |institutional_collection, index| %>
+
     <% if index%3==0 %>
       <div class="row homepage_row">
     <% end %>
         <div class="col-md-4">
-          <a href="/catalog?f[institutional_collection_title_facet][]=<%=institutional_collection.collection_title_formatter%>" class="thumbnail home-header">
-            <%= image_tag("placeholder.jpg")%>
+          <a href="/catalog?f[institutional_collection_title_facet][]=<%= institutional_collection.collection_title_formatter %>" class="thumbnail home-header">
+            <%= image_tag(institutional_collection.thumbnail_url, alt: institutional_collection.collection_title_formatter )%>
           </a>
         <h4><%=institutional_collection.collection_title_formatter %></h4>
         <%= link_to("Rights Description", rights_institutional_collection_path(institutional_collection.id), :data => {:ajax_modal => "trigger"}) %>

--- a/app/views/institutional_collections/_form.html.erb
+++ b/app/views/institutional_collections/_form.html.erb
@@ -30,6 +30,10 @@
             <label for="rights_description">Rights Description:</label>
             <%= f.text_area :rights_description, class: 'form-control' %>
           </div>
+          <div class="form-group">
+            <label for="thumbnail_url">Thumbnail URL:</label>
+            <%= f.text_area :thumbnail_url, class: 'form-control' %>
+          </div>
           <%= f.submit 'Submit', class: 'btn btn-default btn-large' %>
           <button type="button" class="btn btn-default btn-large" data-dismiss="modal" aria-hidden="true">Cancel</button>
         <% end %>

--- a/config/predicate_mappings.yml
+++ b/config/predicate_mappings.yml
@@ -40,7 +40,6 @@
     :is_description_of: isDescriptionOf
     :is_member_of: isMemberOf
     :is_member_of_collection: isMemberOfCollection
-    :has_representative_member: hasRepresentativeMember
     :is_metadata_for: isMetadataFor
     :is_part_of: isPartOf
     :is_subset_of: isSubsetOf

--- a/spec/models/institutional_collection_spec.rb
+++ b/spec/models/institutional_collection_spec.rb
@@ -22,21 +22,6 @@ describe InstitutionalCollection do
     expect(@public_collection.descMetadata.title) == @public_collection.title
   end
 
-  it "can create a representative image association" do
-    @img = Multiresimage.last
-    @public_collection.set_representative_image(@img)
-
-    expect(@public_collection.relationships(:has_representative_member).first).not_to be_nil
-    @public_collection.remove_relationship(:has_representative_member, @img)
-  end
-
-  it "can provide a pid for serving its representative image" do
-    @img = Multiresimage.last
-    @public_collection.set_representative_image(@img)
-
-    expect(@public_collection.representative_image_pid).to eq(@img.pid)
-  end
-
   describe "to_solr" do
     subject { @public_collection.to_solr }
     it "should have title_tesim" do


### PR DESCRIPTION
Fixes #157 

Replaces current representative_member attribute in InstitutionalCollection objects with a thumbnail_url property (stored as a string). Modifies the Institutional Collection form to include a text area where a url can be supplied for an existing multiresimage. Thumbnails on the landing page then use this url to generate images for each collection.