### PR TITLE
259 institutional collection workers

### DIFF
--- a/app/controllers/institutional_collections_controller.rb
+++ b/app/controllers/institutional_collections_controller.rb
@@ -4,6 +4,7 @@ class InstitutionalCollectionsController < CatalogController
 
   include Blacklight::Configurable
   include Blacklight::SearchHelper
+  include Sidekiq::Worker
 
   copy_blacklight_config_from(CatalogController)
 
@@ -139,8 +140,11 @@ class InstitutionalCollectionsController < CatalogController
   end
 
 
-  def remove
-    #TODO delete collection. We will need to change the is_governed_by to default or private and is_representative_of_collection properties on its members first. (They should go back into DIL)
+  def destroy
+    raise "Can't delete DIL Collection" if params[:id] == DIL_CONFIG["institutional_collection"]["Digital Image Library"]["pid"]
+    RemoveInstitutionalCollectionWorker.perform_async(params[:id])
+    flash[:notice] = "Institutional Collection removal is happening in the background."
+    redirect_to institutional_collections_path
   end
 
   private

--- a/app/models/multiresimage.rb
+++ b/app/models/multiresimage.rb
@@ -360,10 +360,8 @@ class Multiresimage < ActiveFedora::Base
   end
 
   def update_institutional_collection(collection)
-    # we are not sure if there is a reason it's better to do this via self.add_relationship(:is_governed_by)
-    # it seems that updating the institutional_collection accomplishes this as well in one step
-    # to use :is_governed by you must first remove any existing relationship (or there will be multiple) and additionally update the institutional_collection
     self.institutional_collection = collection
+    self.save
   end
 
   def get_work_pid

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -7,5 +7,7 @@
  | <%= link_to 'Help', page_path('help') %>
 <% if current_user && current_user.admin? %>
    | <%= link_to "Batch Import", batches_path %>
+   | <%= link_to "Institutional Collections", institutional_collections_path %>
+   | <%= link_to "Sidekiq Dashboard", sidekiq_web_path %>
 <% end %>
 </div>

--- a/app/views/institutional_collections/add_images.html.erb
+++ b/app/views/institutional_collections/add_images.html.erb
@@ -25,7 +25,7 @@
       <% if !document[:id].nil? %>
         <tr>
           <td><a href="/multiresimages/<%=document[:id]%>">
-          <%= image_tag("/image-service" + Riiif::Engine.routes.url_helpers.image_path("#{document[:id]}".gsub!(/:/, '-'), size: ',50')) %></td>
+          <%= image_tag(Riiif::Engine.routes.url_helpers.image_path("#{document[:id]}".gsub!(/:/, '-'), size: ',50')) %></td>
           <td><%=document[:id] %><br /><%=document[:title_display_tesim].first%></td>
           <td><small><%=document[:location_display_tesim].first%></small></td>
         </tr>

--- a/app/views/institutional_collections/index.html.erb
+++ b/app/views/institutional_collections/index.html.erb
@@ -15,7 +15,7 @@
           <td>&nbsp;</td>
           <td> <%= collection.description %> </td>
           <td>
-            <%= button_to('Delete', "/institutional_collections/remove/", class: 'btn btn-xs btn-danger') %>
+            <%= button_to( "Delete", institutional_collection_path(collection), method: :delete, class: "btn btn-xs btn-danger", data: { confirm: "Are you sure you want to delete this collection?" } ) %>
           </td>
         </tr>
       <% end %>

--- a/app/workers/add_institutional_collection_worker.rb
+++ b/app/workers/add_institutional_collection_worker.rb
@@ -5,19 +5,25 @@ class AddInstitutionalCollectionWorker
     begin
       target_collection = InstitutionalCollection.find(target_collection_id)
       dil_collection = InstitutionalCollection.find("inu:dil-00-23655b1f-7029-4fb4-aa10-8ababe0ca63b")
-    rescue ActiveFedora::ObjectNotFoundError => e
-      Sidekiq::Logging.logger("Something went wrong with the collections in your batch")
-      raise
+    rescue ActiveFedora::ObjectNotFoundError
+      logger.error("Something went wrong with one of the collections in your batch")
+      raise "Something went wrong with one of the collections in your batch"
     end
 
     pid_list.each do |pid|
-      # begin
-      #   m = Multiresimage.find(pid)
-      #   m.update_institutional_collection(target_collection) unless m.institutional_collection_id == target_collection.pid
-      # rescue
-      #   Sidekiq::Logging.logger("The image #{m} didn't make it")
-      # end
-      AddImageToInstitutionalCollectionWorker.perform_async(pid, target_collection)
+      begin
+        m = Multiresimage.find(pid)
+        if m.institutional_collection_id == target_collection.pid
+          logger.info("#{m.pid} skipped because it is already governed by #{target_collection.pid}")
+        elsif m.institutional_collection_id != dil_collection.pid
+          logger.error("#{m.pid} skipped because it is no longer in the DIL Collection")  
+        else
+          m.update_institutional_collection(target_collection)
+          logger.info("#{m.pid} added to #{target_collection.pid}")
+        end
+      rescue
+        logger.error("The image #{pid} didn't make it for an unknown reason")
+      end
     end
   end
 end

--- a/app/workers/add_institutional_collection_worker.rb
+++ b/app/workers/add_institutional_collection_worker.rb
@@ -1,0 +1,23 @@
+class AddInstitutionalCollectionWorker
+  include Sidekiq::Worker
+
+  def perform(target_collection_id, pid_list)
+    begin
+      target_collection = InstitutionalCollection.find(target_collection_id)
+      dil_collection = InstitutionalCollection.find("inu:dil-00-23655b1f-7029-4fb4-aa10-8ababe0ca63b")
+    rescue ActiveFedora::ObjectNotFoundError => e
+      Sidekiq::Logging.logger("Something went wrong with the collections in your batch")
+      raise
+    end
+
+    pid_list.each do |pid|
+      # begin
+      #   m = Multiresimage.find(pid)
+      #   m.update_institutional_collection(target_collection) unless m.institutional_collection_id == target_collection.pid
+      # rescue
+      #   Sidekiq::Logging.logger("The image #{m} didn't make it")
+      # end
+      AddImageToInstitutionalCollectionWorker.perform_async(pid, target_collection)
+    end
+  end
+end

--- a/app/workers/remove_institutional_collection_worker.rb
+++ b/app/workers/remove_institutional_collection_worker.rb
@@ -31,7 +31,7 @@ class RemoveInstitutionalCollectionWorker
       current_collection.delete
     else
       logger.error("Skipping collection delete, images remain in #{current_collection.pid}")
-      raise
+      raise "Skipping collection delete, images remain in #{current_collection.pid}"
     end
   end
 

--- a/app/workers/remove_institutional_collection_worker.rb
+++ b/app/workers/remove_institutional_collection_worker.rb
@@ -1,0 +1,52 @@
+class RemoveInstitutionalCollectionWorker
+  include Sidekiq::Worker
+
+  def perform(current_collection_id)
+    current_collection = InstitutionalCollection.find(current_collection_id)
+    target_collection = InstitutionalCollection.find("inu:dil-00-23655b1f-7029-4fb4-aa10-8ababe0ca63b") # DIL COLLECTION
+
+    member_images = get_member_images(current_collection)
+
+    # Change the :is_governed_by relationship to the 
+    # target_collection for each member
+    member_images.each do |solr_object|
+      begin
+        logger.info("Moving #{solr_object['id']} to DIL Collection")
+        m = Multiresimage.find(solr_object['id'])
+        if m.institutional_collection_id == target_collection.pid
+          logger.warn("#{m.pid} skipped because it's already in the target collection")
+        elsif m.institutional_collection_id != current_collection.pid
+          logger.warn("#{m.pid} skipped because it's no longer in the current collection #{current_collection.pid}")
+        else
+          m.update_institutional_collection(target_collection)
+        end
+      rescue ActiveFedora::ObjectNotFoundError
+        logger.error("#{solr_object['id']} not found, skipping")
+      end
+    end
+
+    if get_member_images(current_collection).empty?
+      # Delete the empty collection
+      logger.info("Deleting #{current_collection.pid}...")
+      current_collection.delete
+    else
+      logger.error("Skipping collection delete, images remain in #{current_collection.pid}")
+      raise
+    end
+  end
+
+  private
+  
+  def get_member_images(collection)
+    # Get the current_collection members
+    member_images = []    
+    Multiresimage.find_in_batches('is_governed_by_ssim'=>"info:fedora/#{collection.pid}") do |group|
+      group.each { |solr_object|
+        member_images << solr_object
+      }
+    end
+    member_images
+  end
+end
+
+


### PR DESCRIPTION
Fixes #259 

Sidekiq workers are used for adding images to an institutional collection and for deleting institutional collections. Images are re-associated with the DIL Collection before the institutional collection is deleted.

Changes proposed in this pull request:
* app/workers/add_institutional_collection_worker.rb
* app/workers/remove_institutional_collection_worker.rb
* links to institutional collections index page and sidekiq dashboard added to navigation for admins only