### PR TITLE
Update add images to collection to use batches

### DIFF
--- a/app/controllers/institutional_collections_controller.rb
+++ b/app/controllers/institutional_collections_controller.rb
@@ -90,7 +90,7 @@ class InstitutionalCollectionsController < CatalogController
   end
 
   def confirm_add_images
-    AddInstitutionalCollectionWorker.perform_async(params[:id], params[:pid_list])
+    AddInstitutionalCollectionWorker.add_to_collection(params[:id], params[:pid_list])
     flash[:notice] = "Your request to add images to the collection has been placed in the queue. Check the sidekiq process to monitor for errors"
     redirect_to institutional_collections_path
   end

--- a/app/workers/add_institutional_collection_worker.rb
+++ b/app/workers/add_institutional_collection_worker.rb
@@ -1,28 +1,39 @@
 class AddInstitutionalCollectionWorker
   include Sidekiq::Worker
 
-  def perform(target_collection_id, pid_list)
-    begin
-      target_collection = InstitutionalCollection.find(target_collection_id)
-      dil_collection = InstitutionalCollection.find("inu:dil-00-23655b1f-7029-4fb4-aa10-8ababe0ca63b")
-    rescue ActiveFedora::ObjectNotFoundError
-      logger.error("Something went wrong with one of the collections in your batch")
-      raise "Something went wrong with one of the collections in your batch"
-    end
+  def perform(pid, target_collection_id)
+    target_collection = InstitutionalCollection.find(target_collection_id)
+    dil_collection = InstitutionalCollection.find("inu:dil-00-23655b1f-7029-4fb4-aa10-8ababe0ca63b")
 
-    pid_list.each do |pid|
-      begin
-        m = Multiresimage.find(pid)
-        if m.institutional_collection_id == target_collection.pid
-          logger.info("#{m.pid} skipped because it is already governed by #{target_collection.pid}")
-        elsif m.institutional_collection_id != dil_collection.pid
-          logger.error("#{m.pid} skipped because it is no longer in the DIL Collection")  
-        else
-          m.update_institutional_collection(target_collection)
-          logger.info("#{m.pid} added to #{target_collection.pid}")
-        end
-      rescue
-        logger.error("The image #{pid} didn't make it for an unknown reason")
+    logger.info("#{pid} is being processed.....")
+    m = Multiresimage.find(pid)
+    if m.institutional_collection_id == target_collection.pid
+      logger.info("#{m.pid} skipped because it is already governed by #{target_collection.pid}")
+      raise "#{m.pid} skipped because it is already governed by #{target_collection.pid}"
+    elsif m.institutional_collection_id != dil_collection.pid
+      logger.error("#{m.pid} skipped because it is no longer in the DIL Collection")
+      raise "#{m.pid} skipped because it is no longer in DIL"
+    else
+      m.update_institutional_collection(target_collection)
+      logger.info("#{m.pid} added to #{target_collection.pid}")
+    end
+  end
+
+  def on_success(status, options)
+    logger.info("ALL DONE: Images all moved into: #{options['collection_id']}")
+  end
+
+  def on_complete(status,options)
+    logger.info("Complete with failures: #{status.failures}")
+  end
+
+  def self.add_to_collection(target_collection_id, pid_list)
+    batch = Sidekiq::Batch.new
+    batch.on(:success, self, 'collection_id' => target_collection_id)
+    batch.on(:complete, self, 'collection_id' => target_collection_id)
+    batch.jobs do
+      pid_list.each do |pid|
+        perform_async(pid, target_collection_id)
       end
     end
   end


### PR DESCRIPTION
Fixes #271

Jobs that add images to a collection can now be viewed as a Batch in the Sidekiq interface.  Check the "Batches" Tab in Sidekiq when you add images to a collection.
