### PR TITLE
Sidekiq web route admin only

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
      get '500', :to => 'application#server_error'
   end
 
-  authenticate :user do
+  authenticate :user, lambda { |u| u.admin? } do
     mount Sidekiq::Web => '/sidekiq'
   end
 


### PR DESCRIPTION
Fixes #273 

Fixes issue where Sidekiq Dashboard was open to all authenticated Northwestern Users.

(Test with non-admin user credentials)
