### PR TITLE
Filter Vrawork records out of search results

### DIFF
--- a/app/helpers/dil_blacklight/solr_helpers/object_type_facet.rb
+++ b/app/helpers/dil_blacklight/solr_helpers/object_type_facet.rb
@@ -7,6 +7,7 @@ module DIL_Blacklight::SolrHelpers::ObjectTypeFacet
         # External searches need Works and Images (Hydra app just needs Images).
     if (self.class.name != "ExternalSearchController")
       solr_parameters[:fq] << 'object_type_facet:(Multiresimage)'
+      solr_parameters[:fq] << "-has_model_ssim:\"info:fedora/afmodel:Vrawork\""
     end
   end
 


### PR DESCRIPTION
Fixes #258 

Catalog search results are letting in Vrawork records. This PR adds an :fq filter in the DIL_Blacklight::SolrHelpers::ObjectTypeFacet module to remove them.

Changes proposed in this pull request:
*  app/helpers/dil_blacklight/solr_helpers/object_type_facet.rb
