### PR TITLE
rename tiffs when they are moved

### DIFF
--- a/app/helpers/image_mover.rb
+++ b/app/helpers/image_mover.rb
@@ -1,8 +1,8 @@
 module ImageMover
-  def self.move_img_to_repo(source_path)
+  def self.move_img_to_repo(source_path, tiff_name)
     if Rails.env.staging? || Rails.env.production?
       raise "Wrong image format, not tif" unless File.extname(source_path) == ".tif"
-      destination_path = "#{DIL_CONFIG['repo_location']}#{ File.basename(source_path) }"
+      destination_path = "#{DIL_CONFIG['repo_location']}#{ tiff_name }"
       logger.info("repo_location exist? #{File.exist?(DIL_CONFIG['repo_location'])}")
       logger.info("destination_path: #{destination_path}")
 

--- a/app/models/multiresimage.rb
+++ b/app/models/multiresimage.rb
@@ -45,7 +45,7 @@ class Multiresimage < ActiveFedora::Base
   ###
   # The following datastreams are no longer created for new Multiresimage objects.
   # They remain in "legacy" image records created prior to the riiif migration.
-  has_metadata :name => "DELIV-TECHMD", :type => ActiveFedora::Datastream, :label=>'Image technical metadata'  
+  has_metadata :name => "DELIV-TECHMD", :type => ActiveFedora::Datastream, :label=>'Image technical metadata'
   # Uses the SVG schema to encode jp2 image path, size, crop, and rotation
   has_metadata :name => "DELIV-OPS", :type => SVGDatastream, :label=>'SVG Datastream'
   # External datastream
@@ -94,7 +94,7 @@ class Multiresimage < ActiveFedora::Base
       self.create_archv_exif_datastream(path)
       self.create_jp2(path)
       self.create_archv_img_datastream
-      ImageMover.move_img_to_repo(path)
+      ImageMover.move_img_to_repo(path, tiff_img_name)
       self.edit_groups = [ 'registered' ]
       self.save!
       # Save the multiresimage twice to index correctly


### PR DESCRIPTION
tifs need to be renamed to pid.tif when they are moved to repository