### PR TITLE
Add collection description to popup on homepage

### DIFF
--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -10,7 +10,7 @@
             <%= image_tag(institutional_collection.thumbnail_url, alt: institutional_collection.collection_title_formatter )%>
           </a>
         <h4><%=institutional_collection.collection_title_formatter %></h4>
-        <%= link_to("Rights Description", rights_institutional_collection_path(institutional_collection.id), :data => {:ajax_modal => "trigger"}) %>
+        <%= link_to("About this Collection", rights_institutional_collection_path(institutional_collection.id), :data => {:ajax_modal => "trigger"}) %>
         </div>
     <% if index%3==2 or index == number_of_collections %>
       </div>

--- a/app/views/institutional_collections/rights.html.erb
+++ b/app/views/institutional_collections/rights.html.erb
@@ -1,7 +1,12 @@
 <div data-ajax-modal="container">
-
-<h4>Rights for <%=@collection.collection_title_formatter %></h4>
-<p><%=@collection.rights_description %></p>
-
-<p><%= link_to "Close", catalog_index_path, class: 'btn btn-primary btn-large', :data => {:dismiss => "modal"} %></p>
+  <div class="modal-header">
+	<h2><%=@collection.collection_title_formatter %></h2>
+  </div>
+  <div class="modal-body">
+	<h4>Collection Description</h4>
+	<p><%=@collection.description %></p>
+	<h4>Rights Description</h4>
+	<p><%=@collection.rights_description %></p>
+	<p><%= button_to "Close", catalog_index_path, class: 'btn btn-primary btn-large', :data => {:dismiss => "modal"} %></p>
+  </div>
 </div>


### PR DESCRIPTION
Fixes #302 

Changes to two views so that popup on homepage now shows description of collection as well as the rights description. To test go to homepage and click "About this Collection". 