### PR TITLE
Update solr index for image after edit in menu

### DIFF
--- a/app/controllers/multiresimages_controller.rb
+++ b/app/controllers/multiresimages_controller.rb
@@ -49,6 +49,9 @@ class MultiresimagesController < ApplicationController
     work.datastreams['VRA'].content = updated_work_xml
     work.save
 
+    fedora_object = ActiveFedora::Base.find(params[:pid], :cast=>:true)
+    fedora_object.update_index
+
     head :ok
   end
 


### PR DESCRIPTION
Fixes #293 

After editing an image record in menu, the new values are being merged with the old values, creating issues for the facets. (For example, the agent_name (Creator))

Reindexing just the pid after the update seems to address the issue.

