### PR TITLE
Update solr index for image after edit in menu

### DIFF
--- a/app/controllers/multiresimages_controller.rb
+++ b/app/controllers/multiresimages_controller.rb
@@ -49,6 +49,9 @@ class MultiresimagesController < ApplicationController
     work.datastreams['VRA'].content = updated_work_xml
     work.save
 
+    fedora_object = ActiveFedora::Base.find(params[:pid], :cast=>:true)
+    fedora_object.update_index
+
     head :ok
   end
 


### PR DESCRIPTION
Fixes #293

After editing an image record in Menu, both the old and new facet values remain in solr. (for example, the agent_name_facet, (which displays as Creator on the website). Adding an update index after the edit appears to address the issue.