### PR TITLE
293 reindexing facets

### DIFF
--- a/app/controllers/multiresimages_controller.rb
+++ b/app/controllers/multiresimages_controller.rb
@@ -49,6 +49,9 @@ class MultiresimagesController < ApplicationController
     work.datastreams['VRA'].content = updated_work_xml
     work.save
 
+    fedora_object = ActiveFedora::Base.find(params[:pid], :cast=>:true)
+    fedora_object.update_index
+
     head :ok
   end
 

--- a/app/models/vra_datastream.rb
+++ b/app/models/vra_datastream.rb
@@ -854,7 +854,9 @@ class VRADatastream < ActiveFedora::OmDatastream
     # Add a facet for each period
     self.find_by_terms('//vra:stylePeriodSet/vra:stylePeriod').each do |stylePeriod|
       insert_solr_field_value(stylePeriodSet_array, "stylePeriod_tesim", stylePeriod.text)
-      insert_solr_field_value(stylePeriodSet_array, "stylePeriod_facet", stylePeriod.text)    
+      insert_solr_field_value(stylePeriodSet_array, "stylePeriod_facet", stylePeriod.text)  
+    end  
+    
     return stylePeriodSet_array
   end
 

--- a/app/models/vra_datastream.rb
+++ b/app/models/vra_datastream.rb
@@ -849,14 +849,12 @@ class VRADatastream < ActiveFedora::OmDatastream
     stylePeriodSet_array = {}
     self.find_by_terms('//vra:stylePeriodSet/vra:display').each do |stylePeriodSet_display|
       insert_solr_field_value(stylePeriodSet_array, "stylePeriodSet_display_tesim", stylePeriodSet_display.text)
-      insert_solr_field_value(stylePeriodSet_array, "stylePeriod_facet", stylePeriodSet_display.text)
     end
 
     # Add a facet for each period
     self.find_by_terms('//vra:stylePeriodSet/vra:stylePeriod').each do |stylePeriod|
       insert_solr_field_value(stylePeriodSet_array, "stylePeriod_tesim", stylePeriod.text)
-    end
-
+      insert_solr_field_value(stylePeriodSet_array, "stylePeriod_facet", stylePeriod.text)    
     return stylePeriodSet_array
   end
 


### PR DESCRIPTION
Fixes #293 
Fixes #294 
Fixes #338 

Addresses an issue where Style Period facet was displaying display text rather than style periods, and an issue where when facets were updated, the old value was being retained in the solr doc.
