### PR TITLE
Allow admins to download archival tiffs for all images

### DIFF
--- a/app/controllers/multiresimages_controller.rb
+++ b/app/controllers/multiresimages_controller.rb
@@ -124,7 +124,7 @@ class MultiresimagesController < ApplicationController
 
   def archival_image_proxy
     multiresimage = Multiresimage.find(params[:id])
-    if multiresimage.relationships(:is_governed_by) == ["info:fedora/inu:dil-932ada6f-5cce-45c8-a6b9-139e1e1f281b"]
+    if multiresimage.relationships(:is_governed_by) == ["info:fedora/inu:dil-932ada6f-5cce-45c8-a6b9-139e1e1f281b"]  || current_user.admin?
       filename = "download.tif"
       send_data(multiresimage.ARCHV_IMG.content, :type=>'image/tiff', :filename=>filename) unless multiresimage.ARCHV_IMG.content.nil?
     else

--- a/app/views/multiresimages/_downloads.html.erb
+++ b/app/views/multiresimages/_downloads.html.erb
@@ -15,7 +15,7 @@
         <% end %>
       </div>
       <div class="col-block col-md-3">
-    <% if @multiresimage.relationships(:is_governed_by) == ["info:fedora/inu:dil-932ada6f-5cce-45c8-a6b9-139e1e1f281b"] %>
+    <% if @multiresimage.relationships(:is_governed_by) == ["info:fedora/inu:dil-932ada6f-5cce-45c8-a6b9-139e1e1f281b"] || current_user.admin? %>
       <%= link_to "/multiresimages/archival_image_proxy/#{@multiresimage.pid}", method: :get, class: "btn btn-default btn-block" do %>
         Download Original Image (TIFF) <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span>
       <% end %>


### PR DESCRIPTION
Fixes #291 

A button to download the tif will be displayed for logged in admin users.