### PR TITLE
Admin TIF Download

### DIFF
--- a/app/controllers/multiresimages_controller.rb
+++ b/app/controllers/multiresimages_controller.rb
@@ -127,8 +127,10 @@ class MultiresimagesController < ApplicationController
 
   def archival_image_proxy
     multiresimage = Multiresimage.find(params[:id])
+    logger.info "Request to download tif: #{params[:id]}"
     if multiresimage.relationships(:is_governed_by) == ["info:fedora/inu:dil-932ada6f-5cce-45c8-a6b9-139e1e1f281b"]  || current_user.admin?
       if multiresimage.ARCHV_IMG.dsLocation == nil
+        logger.error "ARCHV-IMG.dsLocation for image is nil: #{params[:id]}"
         flash[:error] = "No TIF location (path) associated with this image."
         redirect_to multiresimage_path
       else
@@ -136,11 +138,13 @@ class MultiresimagesController < ApplicationController
           filename = "download.tif"
           send_data(multiresimage.ARCHV_IMG.content, :type=>'image/tiff', :filename=>filename) unless multiresimage.ARCHV_IMG.content.nil?
         rescue => e
-          flash[:error] = "Problem retrieving tif file for this image: #{e.class}, #{e.message}"
+          logger.error "Problem retrieving tif file: #{multiresimage.ARCHV_IMG.dsLocation}: #{e.class}, #{e.message}"
+          flash[:error] = "Problem retrieving tif file:  #{multiresimage.ARCHV_IMG.dsLocation}: #{e.class}, #{e.message}"
           redirect_to multiresimage_path
         end
       end
     else
+      logger.error "Not authorized to download tif: #{params[:id]}"
       render :nothing => true
     end
   end

--- a/app/controllers/multiresimages_controller.rb
+++ b/app/controllers/multiresimages_controller.rb
@@ -128,8 +128,18 @@ class MultiresimagesController < ApplicationController
   def archival_image_proxy
     multiresimage = Multiresimage.find(params[:id])
     if multiresimage.relationships(:is_governed_by) == ["info:fedora/inu:dil-932ada6f-5cce-45c8-a6b9-139e1e1f281b"]  || current_user.admin?
-      filename = "download.tif"
-      send_data(multiresimage.ARCHV_IMG.content, :type=>'image/tiff', :filename=>filename) unless multiresimage.ARCHV_IMG.content.nil?
+      if multiresimage.ARCHV_IMG.dsLocation == nil
+        flash[:error] = "No TIF location (path) associated with this image."
+        redirect_to multiresimage_path
+      else
+        begin 
+          filename = "download.tif"
+          send_data(multiresimage.ARCHV_IMG.content, :type=>'image/tiff', :filename=>filename) unless multiresimage.ARCHV_IMG.content.nil?
+        rescue => e
+          flash[:error] = "Problem retrieving tif file for this image: #{e.class}, #{e.message}"
+          redirect_to multiresimage_path
+        end
+      end
     else
       render :nothing => true
     end

--- a/app/controllers/multiresimages_controller.rb
+++ b/app/controllers/multiresimages_controller.rb
@@ -127,7 +127,7 @@ class MultiresimagesController < ApplicationController
 
   def archival_image_proxy
     multiresimage = Multiresimage.find(params[:id])
-    if multiresimage.relationships(:is_governed_by) == ["info:fedora/inu:dil-932ada6f-5cce-45c8-a6b9-139e1e1f281b"]
+    if multiresimage.relationships(:is_governed_by) == ["info:fedora/inu:dil-932ada6f-5cce-45c8-a6b9-139e1e1f281b"]  || current_user.admin?
       filename = "download.tif"
       send_data(multiresimage.ARCHV_IMG.content, :type=>'image/tiff', :filename=>filename) unless multiresimage.ARCHV_IMG.content.nil?
     else

--- a/app/views/multiresimages/_downloads.html.erb
+++ b/app/views/multiresimages/_downloads.html.erb
@@ -14,15 +14,19 @@
           Download Small Image (JPG) <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span>
         <% end %>
       </div>
-      <div class="col-block col-md-3">
-    <% if @multiresimage.relationships(:is_governed_by) == ["info:fedora/inu:dil-932ada6f-5cce-45c8-a6b9-139e1e1f281b"] || current_user.admin? %>
-      <%= link_to "/multiresimages/archival_image_proxy/#{@multiresimage.pid}", method: :get, class: "btn btn-default btn-block" do %>
+      
+    <% if @multiresimage.relationships(:is_governed_by) == ["info:fedora/inu:dil-932ada6f-5cce-45c8-a6b9-139e1e1f281b"] || (user_signed_in? && current_user.admin?) %>
+      <div class="col-block col-md-3">  
+        <%= link_to "/multiresimages/archival_image_proxy/#{@multiresimage.pid}", method: :get, class: "btn btn-default btn-block" do %>
         Download Original Image (TIFF) <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span>
-      <% end %>
-    <% end %>
+        <% end %>
       </div>
+    <% end %>
+     
       <% if user_signed_in? && current_user.admin? %>
-      <%= link_to( "Delete Image", multiresimage_path(@multiresimage), method: :delete, class: "btn btn-primary btn-danger", data: { confirm: "Are you sure you want to delete this image?" } ) %>
+      <div class="col-block col-md-3">
+        <%= link_to( "Delete Image", multiresimage_path(@multiresimage), method: :delete, class: "btn btn-primary btn-danger btn-block", data: { confirm: "Are you sure you want to delete this image?" } ) %>
+      </div>
       <% end %>
     </div>
   </div>

--- a/app/views/multiresimages/_downloads.html.erb
+++ b/app/views/multiresimages/_downloads.html.erb
@@ -15,7 +15,7 @@
         <% end %>
       </div>
       <div class="col-block col-md-3">
-    <% if @multiresimage.relationships(:is_governed_by) == ["info:fedora/inu:dil-932ada6f-5cce-45c8-a6b9-139e1e1f281b"] %>
+    <% if @multiresimage.relationships(:is_governed_by) == ["info:fedora/inu:dil-932ada6f-5cce-45c8-a6b9-139e1e1f281b"] || current_user.admin? %>
       <%= link_to "/multiresimages/archival_image_proxy/#{@multiresimage.pid}", method: :get, class: "btn btn-default btn-block" do %>
         Download Original Image (TIFF) <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span>
       <% end %>

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -62,6 +62,9 @@ Rails.application.configure do
   { "params" => params }
   end
 
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = ::Logger::Formatter.new
+
   # For emailing exceptions that occur in the app
   # config.middleware.use ExceptionNotifier,
   #   :email_prefix => "[DIL-Exception STAGING] ",

--- a/lib/tasks/wipeout.rake
+++ b/lib/tasks/wipeout.rake
@@ -1,0 +1,50 @@
+def wipeout_fedora()
+  recs = ActiveFedora::Base.connection_for_pid(0).search('')
+  recs.each do |rec|
+    rec.delete
+  end
+end
+
+def wipeout_solr(solr)
+  solr.delete_by_query('*:*')
+  solr.commit
+end
+
+def wipeout_db
+  [Group, LockedObject, User].each(&:destroy_all)
+end
+
+namespace :images do
+  namespace :wipeout do
+    desc "Reset fedora to empty state"
+    task fedora: :environment do
+      wipeout_fedora()
+    end
+
+    desc "Reset solr to empty state"
+    task solr: :environment do
+      wipeout_solr(ActiveFedora.solr.conn)
+    end
+
+    desc "Reset db to empty state"
+    task db: :environment do
+      wipeout_db
+    end
+  end
+
+  desc "Reset Fedora, Solr, and DB to empty state"
+  task :wipeout => :environment do
+    unless ENV['CONFIRM'] == 'yes'
+      $stderr.puts <<-EOC
+WARNING: This process will destroy all data
+
+Please run `rake images:wipeout CONFIRM=yes` to confirm.
+EOC
+      exit 1
+    end
+
+    ['fedora','solr','db'].each do |component|
+      Rake::Task["images:wipeout:#{component}"].invoke
+    end
+  end
+end


### PR DESCRIPTION
Fixes #291 
Fixes #344 

Admins will see a button to download the archival image (tif) for every multiresimage. 

Also contains rake task to wipe data from Solr/Fedora instance.

