### PR TITLE
350 vra display elements

### DIFF
--- a/app/helpers/transform_xml.rb
+++ b/app/helpers/transform_xml.rb
@@ -13,12 +13,17 @@ module TransformXML
   end
 
   def self.add_display_elements( nokogiri_doc )
+    #remove empty display elements
+    nokogiri_doc.xpath('//vra:display//*[not(text())]').remove
+
     sets = nokogiri_doc.xpath( "//*" ).children[ 1 ].xpath( "./*" )
     sets.each do |node|
       next unless node.element?
       next if node.name == 'dateSet'
       next if node.name == 'subjectSet'
       next if node.name == 'locationSet'
+      #skip if display text is supplied
+      next unless node.children.select {| child | child.name == "display" }.size == 0
 
       display = Nokogiri::XML::Node.new 'vra:display', nokogiri_doc
       all_text_nodes = node.xpath( ".//text()" ).to_a

--- a/app/models/multiresimage.rb
+++ b/app/models/multiresimage.rb
@@ -126,8 +126,11 @@ class Multiresimage < ActiveFedora::Base
     work.update_relation_set(self.pid)
 
     # re-validate the newly updated vra
-    #MultiresimageHelper.validate_vra( work.datastreams["VRA"].content )
-    self.validate_vra( work.datastreams["VRA"].content )
+    if self.validate_vra( work.datastreams["VRA"].content ) == false
+      logger.info(work.datastreams["VRA"].content)
+      validation_errors = get_validation_errors(vra.to_xml)
+      raise "The resulting VRA Work datastream does not validate. #{validation_errors.to_s}"
+    end
 
     work.save!
     work

--- a/app/models/multiresimage.rb
+++ b/app/models/multiresimage.rb
@@ -197,7 +197,11 @@ class Multiresimage < ActiveFedora::Base
         end
 
         #last thing is to validate the vra to ensure it's valid after all the modifications
-        self.validate_vra( vra.to_xml )
+        if self.validate_vra( vra.to_xml ) == false
+          logger.info(vra.to_s)
+          validation_errors = get_validation_errors(vra.to_xml)
+          raise "The resulting VRA image datastream does not validate. #{validation_errors.to_s}"
+        end
         self.datastreams[ 'VRA' ].content = vra.to_xml
         self.datastreams[ 'VRA' ].content
       else

--- a/app/models/vrawork.rb
+++ b/app/models/vrawork.rb
@@ -72,4 +72,9 @@ class Vrawork  < ActiveFedora::Base
     #self.datastreams["VRA"].dirty = true
   end
 
+  def self.find_by_accession_number(accession_nbr)
+    # does not look for "Voyager: ..."
+    ActiveFedora::SolrService.query("location_display_tesim:\"*Accession:#{accession_nbr}*\" AND object_type_facet:Vrawork")
+  end
+
 end

--- a/app/validators/vra_validator.rb
+++ b/app/validators/vra_validator.rb
@@ -1,18 +1,12 @@
 module VraValidator
 
-  # returns nil if there weren't any validation errors
+  # returns false if there are validation errors
   def validate_vra(vra)
-    doc = Nokogiri::XML(vra)
     valid = false
-    errors = []
-    XSD.validate(doc).each do |error|
-      errors << "Validation error: #{error.message}\n"
-    end
 
-    invalid_errors = errors.reject do |err|
-      err.to_s.include?("inu:dil")
-    end
-    if invalid_errors.empty?
+    valid_errors = get_validation_errors(vra)
+
+    if valid_errors.empty?
       valid = true
     end
     valid
@@ -21,5 +15,19 @@ module VraValidator
   def valid_vra?(vra)
     doc = Nokogiri::XML(vra)
     XSD.valid?(doc)
+  end
+
+  def get_validation_errors(vra)
+    doc = Nokogiri::XML(vra)
+    errors = []
+    XSD.validate(doc).each do |error|
+      errors << "Validation error: #{error.message}\n"
+    end
+
+    valid_errors = errors.reject do |err|
+      err.to_s.include?("inu:dil")
+    end
+
+    valid_errors
   end
 end

--- a/app/workers/multiresimages_batch_worker.rb
+++ b/app/workers/multiresimages_batch_worker.rb
@@ -30,13 +30,14 @@ class MultiresimagesBatchWorker
       FileUtils.cp(tiff_file, "tmp/#{m.tiff_img_name}")
       m.create_datastreams_and_persist_image_files("tmp/#{m.tiff_img_name}")
     rescue StandardError => e
-      # find and delete any orphaned work from errors during Multiresimage.new
-      remove_orphaned_work(accession_number)
-
+      
       unless m.nil?
         m.vraworks.first.delete if m.vraworks.first
         m.delete
       end
+
+      # find and delete any orphaned work from errors during Multiresimage.new
+      remove_orphaned_work(accession_number)
          
       #check that everything was successfully cleaned up
       if Multiresimage.existing_image?(accession_number)


### PR DESCRIPTION
Fixes #350 
Currently, if display elements are provided, the Images application is duplicating the display element  and creating invalid VRA. 

Fixes #347 
Currently, if a batch ingest record fails at specific points an orpahned VRAWork record is created in Images. This causes subsequent retries to fail with: `Existing image found with this accession number:`

Documentation for batch ingest (VRA) xml input requirement, xml transformations and validations for the Images application:
 * [https://github.com/nulib/images/wiki/Batch-Ingest-Input-VRA-XML](https://github.com/nulib/images/wiki/Batch-Ingest-Input-VRA-XML)



**Changes proposed in this pull request:**

* Fixes bugs in validation check of VRA against the schema (both work and image), after it is transformed during a batch ingest of an images so that invalid VRA does not go into Images.
*  (new feature) During batch ingest, if a display element for an element set is provided and is not empty, use it. Only if it is not provided, proceed with the concatenation rules that are already in place to create a display element for a set. (Note that this does not apply for locationSet, subjectSet or dateSet, which operate differently.)
* After an error occurs during batch ingest of an image, look for orphaned work records and remove from Images, so that the `Existing image found with this accession number:` errors do not occur on retries.
