### PR TITLE
Add an endpoint that renders a list of member pids as text

### DIFF
--- a/app/views/institutional_collections/show.html.erb
+++ b/app/views/institutional_collections/show.html.erb
@@ -14,6 +14,8 @@
 
     <%= link_to("Edit Collection Info", edit_institutional_collection_path(@collection), :data => {:ajax_modal => "trigger"}, class: 'btn btn-default btn-large') %>
 
+    <%= link_to("Image pids for collection", pids_institutional_collection_path(@collection), class: 'btn btn-default btn-large') %>
+
     <br/><br>
 
     <form class="search-query-form clearfix" method="get" action="<%=add_images_institutional_collection_path(@collection.id)%>" accept-charset="UTF-8">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,7 @@ Rails.application.routes.draw do
       get 'images'
       get 'confirm_add_images'
       get 'rights'
+      get 'pids', defaults: { format: 'text' }
       post 'remove_image'
       post 'remove_collection_items_to_dil'
     end


### PR DESCRIPTION
For convenience, a button is located on the InstitutionalCollection#show pages as well.