### PR TITLE
Make collection description field a text area

### DIFF
--- a/app/views/institutional_collections/_form.html.erb
+++ b/app/views/institutional_collections/_form.html.erb
@@ -24,7 +24,7 @@
           <% end %>
           <div class="form-group">
             <label for="description">Collection Description:</label>
-            <%= f.text_field :description, class: 'form-control' %>
+            <%= f.text_area :description, class: 'form-control' %>
           </div>
           <div class="form-group">
             <label for="rights_description">Rights Description:</label>


### PR DESCRIPTION
Small change to the institutional collection edit form, making the collection description field a text area instead of a text field.
