### PR TITLE
cleaned up batch worker to make the logic a bit more straight forward

### DIFF
--- a/app/models/multiresimage.rb
+++ b/app/models/multiresimage.rb
@@ -93,6 +93,7 @@ class Multiresimage < ActiveFedora::Base
       j = Multiresimage.find(self.pid)
       j.save!
     rescue StandardError => e
+      File.unlink(self.tiff_derivative_path) if File.exist?(self.tiff_derivative_path)
       self.delete
       raise e
     end

--- a/app/workers/multiresimages_batch_worker.rb
+++ b/app/workers/multiresimages_batch_worker.rb
@@ -20,17 +20,9 @@ class MultiresimagesBatchWorker
     ready_xml = TransformXML.prepare_vra_xml(nokogiri_doc.to_xml)
     pid = mint_pid("dil")
 
-    begin
-      logger.info("Batch worker starting - accession: #{accession_number}, pid: #{pid}")
-      m = Multiresimage.create(pid: pid, vra_xml: ready_xml, from_menu: true)
-      m.create_datastreams_and_persist_image_files(tiff_file)
-    rescue StandardError => e
-      m.delete unless m.nil? || m.destroyed
-      File.unlink(m.tiff_derivative_path) if File.exist?(m.tiff_derivative_path)
-
-      # raise the exception so this particular job fails
-      raise "Had a problem saving #{tiff_file}: #{e.message}"
-    end
+    logger.info("Batch worker starting - accession: #{accession_number}, pid: #{pid}")
+    m = Multiresimage.create(pid: pid, vra_xml: ready_xml, from_menu: true)
+    m.create_datastreams_and_persist_image_files(tiff_file)
 
     logger.info("Batch worker finished - accession: #{accession_number}, pid: #{pid}")
   end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,2 +1,3 @@
 :pidfile: ./tmp/pids/sidekiq.pid
 :logfile: ./log/sidekiq.log
+:concurrency: 1


### PR DESCRIPTION
The main changes in this PR are removing the need to copy the original tiff to another location so we can create a derivative of it and getting rid of some of the extraneous checks and ensures. 

