### PR TITLE
Upgrade riiif gem to 1.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ source 'http://rubygems.org' do
   gem 'hydra-ldap'
   gem 'high_voltage'
   gem 'powerpoint', :git => 'https://github.com/benjaminwood/powerpoint.git'
-  gem 'riiif', '~> 1.4'
+  gem 'riiif', '~> 1.5'
   gem 'openseadragon'
   gem 'whenever', :require => false
   gem 'activerecord-session_store'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -409,7 +409,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    riiif (1.4.1)
+    riiif (1.5.0)
       railties (>= 4.2, < 6)
     rsolr (1.0.13)
       builder (>= 2.1.2)
@@ -583,7 +583,7 @@ DEPENDENCIES
   pry!
   rails (~> 4.2)!
   rb-readline!
-  riiif (~> 1.4)!
+  riiif (~> 1.5)!
   rsolr!
   rspec-rails!
   rspec-steps!


### PR DESCRIPTION
Fixes #414

- Run `bundle install` to test locally (Gemfile change).
- Requires a `Rails.cache.clean` to fix the problem with image widths.